### PR TITLE
Fix issue #12: allow passing tuple to metavar in `add_argument()`

### DIFF
--- a/R/argparse.R
+++ b/R/argparse.R
@@ -192,6 +192,11 @@ convert_..._to_arguments <- function(mode, ...) {
         choices <- convert_argument(argument_list[[ii]])
         proposed_arguments[ii] <- sprintf("choices=%s", choices)
     }
+		if(mode == "add_argument" && any(grepl("metavar=", proposed_arguments))) {
+			ii <- grep("metavar=", proposed_arguments)
+			metavar <- argument_list[[ii]]
+			proposed_arguments[[ii]] <- sprintf('metavar=(%s)', paste('"', metavar, '"', collapse = ",", sep = ""))
+		}
     # Make defaults are what Python wants, if specified
     default_string <- switch(mode,
            add_argument = "default=", 


### PR DESCRIPTION
I have added functionality to pass a tuple to the metavar argument in add_argument().
I have tested this using calls of the form
`add_argument(..., metavar = c(...))`
`add_argument(..., metavar = list(...))`
Please use the code (or not) as you see fit.